### PR TITLE
MOB-1340 Workflow does not publish to Cocoapods

### DIFF
--- a/.github/workflows/deploy-to-cocoapods.yml
+++ b/.github/workflows/deploy-to-cocoapods.yml
@@ -16,7 +16,10 @@ jobs:
     - name: Install Cocoapods
       run: gem install cocoapods
     
-    # shortcut version
-    - uses: michaelhenry/deploy-to-cocoapods-github-action@1.0.9
+    - name: Deploy Thunderhead pod to Cocoapods
+      run: |
+        set -eo pipefail
+        pod lib lint --allow-warnings
+        pod trunk push --allow-warnings
       env:
         COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}


### PR DESCRIPTION
Create a new Test cocoapod to verify the script (Thunderhead-Test)
@andreipop  Let me know if we want to delete this trunk once the script is validated.
Updated deploy to cocoapods script to publish Thunderhead pod to cocoapods.

Also updated the secret with the new Authorisation Token.